### PR TITLE
[Permissions] Make who_or_what a required arg in syntax

### DIFF
--- a/changelog.d/permissions/2960.bugfix.rst
+++ b/changelog.d/permissions/2960.bugfix.rst
@@ -1,0 +1,1 @@
+Make who_or_what a required argument in the syntax

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -283,7 +283,7 @@ class Permissions(commands.Cog):
         ctx: commands.Context,
         allow_or_deny: RuleType,
         cog_or_command: CogOrCommand,
-        *who_or_what: GlobalUniqueObjectFinder,
+        who_or_what: GlobalUniqueObjectFinder,
     ):
         """Add a global rule to a command.
 
@@ -314,7 +314,7 @@ class Permissions(commands.Cog):
         ctx: commands.Context,
         allow_or_deny: RuleType,
         cog_or_command: CogOrCommand,
-        *who_or_what: GuildUniqueObjectFinder,
+        who_or_what: GuildUniqueObjectFinder,
     ):
         """Add a rule to a command in this server.
 
@@ -343,7 +343,7 @@ class Permissions(commands.Cog):
         self,
         ctx: commands.Context,
         cog_or_command: CogOrCommand,
-        *who_or_what: GlobalUniqueObjectFinder,
+        who_or_what: GlobalUniqueObjectFinder,
     ):
         """Remove a global rule from a command.
 
@@ -366,7 +366,7 @@ class Permissions(commands.Cog):
         self,
         ctx: commands.Context,
         cog_or_command: CogOrCommand,
-        *who_or_what: GlobalUniqueObjectFinder,
+        who_or_what: GlobalUniqueObjectFinder,
     ):
         """Remove a server rule from a command.
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
At the moment the syntax says who_or_what is not required in the command.
The docstring conflicts this, saying that who_or_what is needed.
Actual behaviour also reflects this, with who_or_what being required.
This affects `addglobalrule`, `addguildrule`, `removegloalrule` and `removeguildrule`.